### PR TITLE
Bump version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,10 +3,10 @@
   "description": "A clock for showing a second timezone in the panel.", 
   "name": "MultiClock", 
   "shell-version": [
-    "3.36", "40.0"
+    "3.36", "40.0", "40.1"
   ], 
   "url": "https://github.com/mibus/MultiClock",
   "uuid": "MultiClock@mibus.org",
   "settings-schema":  "org.gnome.shell.extensions.mibusMultiClock",
-  "version": 8
+  "version": 9
 }


### PR DESCRIPTION
Not sure if it needs some more code changes or a full reboot to actually be compatible, but after cloning this fork into `~/.local/share/gnome-shell/extensions/MultiClock@mibus.org` and restarting Wayland GNOME nothing changed in the top bar.