### PR TITLE
Support for gnome-shell 41,42 + popup fix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,6 +19,9 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
+const Config = imports.misc.config;
+const [major_ver, minor_ver] = Config.PACKAGE_VERSION.split('.').map(s => Number(s));
+
 const UPDATE_INTERVAL = 5000;
 
 const Timezones = [
@@ -31,103 +34,198 @@ const Timezones = [
     'Pacific/Auckland',
 ];
 
-const AltTimeMenuButton = new Lang.Class({
-	Name: 'AltTimeMenuButton',
-	Extends: PanelMenu.Button,
+let AltTimeMenuButton = null;
 
-    _schema: null,
-    _clock_settings: null,
-    selected_tz: null,
-
-    _init: function() {
-
-        let item;
-
-        let menuAlignment = 0.25;
-        this.parent(menuAlignment);
-
-	// Widget set-up
-        this._clockDisplay = new St.Label({text: 'Initialising', opacity: 150});
-        this.actor.add_actor(this._clockDisplay);
-	this.actor.set_y_align(Clutter.ActorAlign.CENTER);
-
-	// Importing clock-related things from outside
-        this._clock = new GnomeDesktop.WallClock();
-	this._clock_settings = new Gio.Settings({ schema: 'org.gnome.desktop.interface' });
-
-	// Loading our own settings
-        this._schema = Convenience.getSettings();
-	let tzid = this._schema.get_string('timezone');
-
-	// Making the main timezone selection menu
-	var seen_tz = false;
-	for (var i = 0; i < Timezones.length; i++) {
-		let tz = Timezones[i];
-		if (tz == tzid)
-			seen_tz = true;
-		this.menu.addAction (
-			tz,
-			Lang.bind(this, function () {
-				this.set_tz (tz);
-			}));
-	}
-
-	// Adding "Other..."
-	this.menu.addAction ('Other...',
-		Lang.bind(this, function() {
-		    var d = new CustomDialog(this);
-		    d.open();
-		}));
-
-	// Internally loading our stored timezone, including adding it as an extra menu option if appropriate
-	if (seen_tz)
-		this.set_tz (tzid);
-        else
-		this.set_custom_tz(tzid);
-    },
-
-    set_custom_tz: function (tzid) {
-	this.set_tz(tzid);
-	this.menu.addAction (tzid,
-			Lang.bind(this, function () {
-				this.set_tz (tzid);
-			}));
-    },
-
-    set_tz: function (tzid) {
-	this.selected_tz = GLib.TimeZone.new(tzid);
-	this.update_time();
-	this._schema.set_string('timezone', tzid);
-    },
-
-    get_alternate_time_string: function() {
-	if (!this.selected_tz)
-	    return "Initialising";
-
-        var now = GLib.DateTime.new_now(this.selected_tz);
-	if (this._clock_settings.get_enum('clock-format')) { // 12-Hour
-		var remote_time = now.format('%l:%M %p %Z');
-	} else { // 24-Hour
-		var remote_time = now.format('%R %Z');
-	}
-
-	return remote_time;
-    },
-
-    enable: function() {
-        this.clock_signal_id = this._clock.connect('notify::clock', Lang.bind(this, this.update_time));
+if (major_ver < 41) {
+    global.log ('GNOME-Shell 3.6+ detected...');
+    AltTimeMenuButton = new Lang.Class({
+        Name: 'AltTimeMenuButton',
+        Extends: PanelMenu.Button,
+    
+        _schema: null,
+        _clock_settings: null,
+        selected_tz: null,
+    
+        _init: function() {
+    
+            let item;
+    
+            let menuAlignment = 0.25;
+            this.parent(menuAlignment);
+    
+        // Widget set-up
+            this._clockDisplay = new St.Label({text: 'Initialising', opacity: 150});
+            this.actor.add_actor(this._clockDisplay);
+        this.actor.set_y_align(Clutter.ActorAlign.CENTER);
+    
+        // Importing clock-related things from outside
+            this._clock = new GnomeDesktop.WallClock();
+        this._clock_settings = new Gio.Settings({ schema: 'org.gnome.desktop.interface' });
+    
+        // Loading our own settings
+            this._schema = Convenience.getSettings();
+        let tzid = this._schema.get_string('timezone');
+    
+        // Making the main timezone selection menu
+        var seen_tz = false;
+        for (var i = 0; i < Timezones.length; i++) {
+            let tz = Timezones[i];
+            if (tz == tzid)
+                seen_tz = true;
+            this.menu.addAction (
+                tz,
+                Lang.bind(this, function () {
+                    this.set_tz (tz);
+                }));
+        }
+    
+        // Adding "Other..."
+        this.menu.addAction ('Other...',
+            Lang.bind(this, function() {
+                var d = new CustomDialog(this);
+                d.open();
+            }));
+    
+        // Internally loading our stored timezone, including adding it as an extra menu option if appropriate
+        if (seen_tz)
+            this.set_tz (tzid);
+            else
+            this.set_custom_tz(tzid);
+        },
+    
+        set_custom_tz: function (tzid) {
+        this.set_tz(tzid);
+        this.menu.addAction (tzid,
+                Lang.bind(this, function () {
+                    this.set_tz (tzid);
+                }));
+        },
+    
+        set_tz: function (tzid) {
+        this.selected_tz = GLib.TimeZone.new(tzid);
         this.update_time();
-    },
+        this._schema.set_string('timezone', tzid);
+        },
+    
+        get_alternate_time_string: function() {
+        if (!this.selected_tz)
+            return "Initialising";
+    
+            var now = GLib.DateTime.new_now(this.selected_tz);
+        if (this._clock_settings.get_enum('clock-format')) { // 12-Hour
+            var remote_time = now.format('%l:%M %p %Z');
+        } else { // 24-Hour
+            var remote_time = now.format('%R %Z');
+        }
+    
+        return remote_time;
+        },
+    
+        enable: function() {
+            this.clock_signal_id = this._clock.connect('notify::clock', Lang.bind(this, this.update_time));
+            this.update_time();
+        },
+    
+        disable: function() {
+        this._clock.disconnect(this.clock_signal_id);
+        },
+    
+        update_time: function() {
+            this._clockDisplay.set_text(this.get_alternate_time_string());
+        },
+    
+    });
+}
+// QMC: Support for Gnome-Shell 41,42 below.
+else {
+    global.log ('GNOME-Shell 41+ detected...');
+    AltTimeMenuButton = GObject.registerClass(
+        class AltTimeMenuButton extends PanelMenu.Button {
+            _init() {
+                super._init(0.25 /* menu alignment */, "AltTimeMenuButton");
 
-    disable: function() {
-	this._clock.disconnect(this.clock_signal_id);
-    },
+                // Widget set-up
+                this._clockDisplay = new St.Label({text: 'Initialising', opacity: 150});
+                this.actor.add_actor(this._clockDisplay);
+                this.actor.set_y_align(Clutter.ActorAlign.CENTER);
 
-    update_time: function() {
-        this._clockDisplay.set_text(this.get_alternate_time_string());
-    },
+                // Importing clock-related things from outside
+                this._clock = new GnomeDesktop.WallClock();
+                this._clock_settings = new Gio.Settings({ schema: 'org.gnome.desktop.interface' });
 
-});
+                // Loading our own settings
+                this._schema = Convenience.getSettings();
+                let tzid = this._schema.get_string('timezone');
+
+                // Making the main timezone selection menu
+                var seen_tz = false;
+                for (var i = 0; i < Timezones.length; i++) {
+                    let tz = Timezones[i];
+                    if (tz == tzid)
+                        seen_tz = true;
+                    this.menu.addAction (
+                        tz,
+                        Lang.bind(this, function () {
+                        this.set_tz (tz);
+                    }));
+                }
+
+                // Adding "Other..."
+                this.menu.addAction ('Other...',
+                Lang.bind(this, function() {
+                    var d = new CustomDialog(this);
+                    d.open();
+                }));
+
+                // Internally loading our stored timezone, including adding it as an extra menu option if appropriate
+                if (seen_tz)
+                    this.set_tz (tzid);
+                else
+                    this.set_custom_tz(tzid);
+            }
+
+            set_custom_tz(tzid) {
+                this.set_tz(tzid);
+                this.menu.addAction (tzid,
+                    Lang.bind(this, function () {
+                        this.set_tz (tzid);
+                    }));
+            }
+
+            set_tz(tzid) {
+                this.selected_tz = GLib.TimeZone.new(tzid);
+                this.update_time();
+                this._schema.set_string('timezone', tzid);
+            }
+
+            get_alternate_time_string() {
+                if (!this.selected_tz)
+                    return "Initialising";
+
+                var now = GLib.DateTime.new_now(this.selected_tz);
+                if (this._clock_settings.get_enum('clock-format')) { // 12-Hour
+                    var remote_time = now.format('%l:%M %p %Z');
+                } else { // 24-Hour
+                    var remote_time = now.format('%R %Z');
+                }
+
+                return remote_time;
+            }
+
+            enable() {
+                this.clock_signal_id = this._clock.connect('notify::clock', Lang.bind(this, this.update_time));
+                this.update_time();
+            }
+
+            disable() {
+                this._clock.disconnect(this.clock_signal_id);
+            }
+
+            update_time() {
+                this._clockDisplay.set_text(this.get_alternate_time_string());
+            }
+    });
+}
 
 function MultiClock() {
     this._init();
@@ -144,7 +242,6 @@ MultiClock.prototype = {
         this.button.enable();
 	Main.ATMButton = this.button;
 	global.log (this.button);
-	global.log ('GNOME-Shell 3.6+ detected...');
 	Main.panel.addToStatusArea('multiclock',this.button,1,'center');
 	Main.panel.menuManager.addMenu(this.button.menu);
     },
@@ -168,9 +265,7 @@ var CustomDialog = GObject.registerClass(class extends ModalDialog.ModalDialog {
         let label = new St.Label({ style_class: 'run-dialog-label',
                                    text: _("Enter a timezone identifier") });
 
-        this.contentLayout.add(label, { x_fill: false,
-                                        x_align: St.Align.START,
-                                        y_align: St.Align.START });
+        this.contentLayout.add(label);
 
         let entry = new St.Entry({ style_class: 'run-dialog-entry',
                                    can_focus: true });
@@ -179,7 +274,7 @@ var CustomDialog = GObject.registerClass(class extends ModalDialog.ModalDialog {
 
 	global.log('In constructor for CustomDialog.');
         this._entryText = entry.clutter_text;
-        this.contentLayout.add(entry, { y_align: St.Align.START });
+        this.contentLayout.add(entry);
         this.setInitialKeyFocus(this._entryText);
         this.setButtons([{ action: this.close.bind(this),
                            label: _("Close"),
@@ -206,4 +301,3 @@ function init(meta) {
 
     return new MultiClock();
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -3,10 +3,10 @@
   "description": "A clock for showing a second timezone in the panel.", 
   "name": "MultiClock", 
   "shell-version": [
-    "3.36", "40.0", "40.1"
+    "3.36", "40.0", "40.1", "41", "42"
   ], 
   "url": "https://github.com/mibus/MultiClock",
   "uuid": "MultiClock@mibus.org",
   "settings-schema":  "org.gnome.shell.extensions.mibusMultiClock",
-  "version": 9
+  "version": 10
 }


### PR DESCRIPTION
Hi Robert,

Followed your comment about the potential refactoring of the extension.
Tested in Fedora 36 (Gnome 42.3)

Additionally fixed an issue when clicking on "Other ...", consequence of the removal of meta from child objects in 3.38.

Not tested in any other versions of Gnome.

Best!